### PR TITLE
Fix: conflicting version hash

### DIFF
--- a/P/Pluto/Versions.toml
+++ b/P/Pluto/Versions.toml
@@ -1,2 +1,2 @@
 ["0.19.29"]
-git-tree-sha1 = "c8faf2bdb5843a0bc1689f1fc17a28d61e56e33a"
+git-tree-sha1 = "5d03fac7fb58345c186431e55ddd3aa8d828c1a5"


### PR DESCRIPTION
This version has doesn't match General registry and hence sync fails